### PR TITLE
Added bootstrap-callout plugin

### DIFF
--- a/book.json
+++ b/book.json
@@ -2,7 +2,8 @@
   "root": "./docs",
   "plugins": [ 
     "collapsible-chapters",
-    "youtube"
+    "youtube",
+    "bootstrap-callout" 
   ],
   "pluginsConfig": {
     "collapsible-chapters": {}

--- a/docs/basics/scripts/key-concepts.md
+++ b/docs/basics/scripts/key-concepts.md
@@ -34,7 +34,7 @@ At any time, you can load any of the scripts listed from the left dock-pane by c
 
 It is also possible to remove any scripts by clicking the delete ![Script Editor](../../assets/images/button-delete-black.png) icon next to the script you wish to delete in the script list. 
 
-> #### danger::Please Note
+> #### danger::
 > Deleting a script here will not remove the script reference in a given screen so take care when you remove a script. You will need to make sure any screen that referenced the given script is updated to a new script or the reference is removed.
 
 ## Referencing a Script from a screen

--- a/docs/basics/scripts/key-concepts.md
+++ b/docs/basics/scripts/key-concepts.md
@@ -32,7 +32,10 @@ At any time, you can load any of the scripts listed from the left dock-pane by c
 
 ## Delete Script
 
-It is also possible to remove any scripts by clicking the delete ![Script Editor](../../assets/images/button-delete-black.png) icon next to the script you wish to delete in the script list. Deleting a script here will not remove the script reference in a given screen so take care when you remove a script. You will need to make sure any screen that referenced the given script is updated to a new script or the reference is removed.
+It is also possible to remove any scripts by clicking the delete ![Script Editor](../../assets/images/button-delete-black.png) icon next to the script you wish to delete in the script list. 
+
+> #### danger::Please Note
+> Deleting a script here will not remove the script reference in a given screen so take care when you remove a script. You will need to make sure any screen that referenced the given script is updated to a new script or the reference is removed.
 
 ## Referencing a Script from a screen
 

--- a/docs/basics/styles/key-concepts.md
+++ b/docs/basics/styles/key-concepts.md
@@ -31,7 +31,9 @@ At any time, you can load any of the styles listed from the left dock-pane by cl
 
 ## Delete Style
 
-It is also possible to remove any style by clicking the delete ![Script Editor](../../assets/images/button-delete-black.png) icon next to the style you wish to delete in the script list. Deleting a style here will not remove the style reference in a given screen so take care when you remove a style. You will need to make sure any screen that referenced the given style is updated to a new style or the reference is removed.
+It is also possible to remove any style by clicking the delete ![Script Editor](../../assets/images/button-delete-black.png) icon next to the style you wish to delete in the script list. 
+> #### danger::
+> Deleting a script here will not remove the script reference in a given screen so take care when you remove a script. You will need to make sure any screen that referenced the given script is updated to a new script or the reference is removed.
 
 ## Referencing a Style from a screen
 


### PR DESCRIPTION
Added the [bootstrap-callout plugin](https://plugins.gitbook.com/plugin/bootstrap-callout) so that in Gitbook, we can specifically call attention to certain sections of the documentation to help make sure the reader understands important concepts or ramifications of doing certain actions.

Added a callout to the Styles and Scripts documents concerning actions that need taken after they delete a Style or Script from FrontEnd Creator.

Preview it here:  https://jawa-the-hutt.gitbooks.io/frontend-creator-fork/content/basics/styles/key-concepts.html 